### PR TITLE
Updated VNet NAT Gateway's "public ip zones" and ".gitignore" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ override.tf.json
 .terraformrc
 terraform.rc
 .terraform.*
+.terraform.lock.hcl
+**/.terraform.lock.hcl/*

--- a/modules/vnet/providers.tf
+++ b/modules/vnet/providers.tf
@@ -1,3 +1,0 @@
-# provider "azurerm" {
-#   features {}
-# }

--- a/modules/vnet/variables.tf
+++ b/modules/vnet/variables.tf
@@ -176,7 +176,7 @@ variable "create_public_ip" {
 variable "public_ip_zones" {
   description = "Public ip Zones to configure for NAT Gateway."
   type        = list(string)
-  default     = ["1", "2"]
+  default     = null
 }
 variable "public_ip_ids" {
   description = "List of public ips to use in case a public IP for NAT Gateway is not being created."

--- a/versions.tf
+++ b/versions.tf
@@ -6,11 +6,11 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.0.2"
+      version = ">=2.13.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.0.2"
+      version = ">=2.6"
     }
   }
 }


### PR DESCRIPTION
### Purpose

- Updated VNet NAT gateway's public IP zones from "1,2" to "null" to create public IP in the default zone.
- Updated .gitignore file to ignore pushing".terraform.local.hcl" file.